### PR TITLE
Use instanceof instead of string casting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var toString = {}.toString;
-
-module.exports = Array.isArray || function (arr) {
-  return toString.call(arr) === '[object Array]';
+module.exports = Array.isArray || function isArray (arr) {
+  return arr instanceof Array;
 };


### PR DESCRIPTION
This is what instanceof was made for.
Who came up with that string comparison anyways?

![gottz/isarray](https://ci.testling.com/gottz/isarray.png)
https://ci.testling.com/gottz/isarray

Maybe tag it 3.0.0 to ensure this doesn't break anything and flag 2 as out of date since it sure does not work with inheritance.

Example of where this makes a difference:
![image](https://user-images.githubusercontent.com/559564/121117289-30e4bf80-c818-11eb-8a40-be43ef3aa9b8.png)
![image](https://user-images.githubusercontent.com/559564/121117489-7bfed280-c818-11eb-89fc-daa5231db632.png)

Even if JavaScript engines don't implement Array.prototype.isArray, instanceof is the correct and spec compliant solution for this problem.

![image](https://user-images.githubusercontent.com/559564/121118328-f2e89b00-c819-11eb-8754-cac6da397284.png)
https://262.ecma-international.org/11.0/#sec-isarray
Proxy didn't exist before instanceof either so that can be skipped entirely from checking.

If we would want a fully spec compliant isArray, it would need to check against this spec:
![image](https://user-images.githubusercontent.com/559564/121118852-de58d280-c81a-11eb-87b9-85dce69e6e9e.png)

https://262.ecma-international.org/11.0/#sec-array-exotic-objects

I still think instanceof would be a quicker and better solution than string casting.