### PR TITLE
Rework the array check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var toString = {}.toString;
-
 module.exports = Array.isArray || function (arr) {
-  return toString.call(arr) === '[object Array]';
+  return arr && arr.constructor === Array;
 };


### PR DESCRIPTION
I think this is way better. More readable and straghtforward. No confusing string casts or such.

Compatibility level should be the same, as far as I'm concerned.
[`Array()` constructor](https://caniuse.com/mdn-javascript_builtins_array_array) is avaliable down to IE6.
[`constructor` property](https://caniuse.com/mdn-javascript_builtins_object_constructor) is avaliable down to IE8.

Possibly even better performance, because of removed string cast and comparison. Not benchmarked it though.