### PR TITLE
fix: use HTTPS repository URL instead of SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.5",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/juliangruber/isarray.git"
+    "url": "git+https://github.com/juliangruber/isarray.git"
   },
   "homepage": "https://github.com/juliangruber/isarray",
   "main": "index.js",


### PR DESCRIPTION
The repository URL in package.json uses `ssh://` which requires SSH keys. Changed to `git+https://` which works for all consumers without SSH configuration.

This is a metadata-only change - no runtime code, dependencies, or tests are affected.